### PR TITLE
Improve field resolvers and errors

### DIFF
--- a/examples/movies/main.go
+++ b/examples/movies/main.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"context"
 	"log"
 	"net/http"
 
-	"github.com/rigglo/gql/pkg/handler"
-
 	"github.com/rigglo/gql/pkg/gql"
+	"github.com/rigglo/gql/pkg/handler"
 )
 
 func main() {
@@ -63,7 +61,7 @@ var (
 		Fields: gql.InputFields{
 			&gql.InputField{
 				Name:         "asd",
-				Type:         gql.String,
+				Type:         gql.NewNonNull(gql.String),
 				DefaultValue: "defoocska",
 			},
 		},
@@ -77,7 +75,7 @@ var (
 				Name:        "top_movies",
 				Type:        gql.NewList(MovieType),
 				Description: "",
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
 					return []Movie{
 						Movie{
 							ID:    "22424234",
@@ -97,16 +95,15 @@ var (
 				Arguments: gql.Arguments{
 					&gql.Argument{
 						Name: "asd",
-						Type: FooInput,
+						Type: gql.NewNonNull(FooInput),
 					},
 					&gql.Argument{
 						Name: "bar",
 						Type: gql.String,
 					},
 				},
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
-					log.Println(args)
-					return args["asd"].(map[string]interface{})["asd"], nil
+				Resolver: func(ctx gql.Context) (interface{}, error) {
+					return ctx.Args()["asd"].(map[string]interface{})["asd"], nil
 				},
 			},
 		},

--- a/examples/pets/main.go
+++ b/examples/pets/main.go
@@ -98,35 +98,35 @@ var (
 			&gql.Field{
 				Name: "dog",
 				Type: DogType,
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
 					return Doggo, nil
 				},
 			},
 			&gql.Field{
 				Name: "cat",
 				Type: CatType,
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
 					return Catcy, nil
 				},
 			},
 			&gql.Field{
 				Name: "pet",
 				Type: gql.NewList(PetInterface),
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
 					return []interface{}{Catcy, Doggo}, nil
 				},
 			},
 			&gql.Field{
 				Name: "catOrDog",
 				Type: gql.NewList(CatOrDogUnion),
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
 					return []interface{}{Catcy, Doggo}, nil
 				},
 			},
 			&gql.Field{
 				Name: "someErr",
 				Type: gql.NewList(CatOrDogUnion),
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
 					return nil, gql.NewError(ctx, "asdasdasd", map[string]interface{}{"code": "SOME_ERR_CODE"})
 				},
 			},

--- a/examples/pets/main.go
+++ b/examples/pets/main.go
@@ -127,7 +127,7 @@ var (
 				Name: "someErr",
 				Type: gql.NewList(CatOrDogUnion),
 				Resolver: func(ctx gql.Context) (interface{}, error) {
-					return nil, gql.NewError(ctx, "asdasdasd", map[string]interface{}{"code": "SOME_ERR_CODE"})
+					return nil, gql.NewError("asdasdasd", map[string]interface{}{"code": "SOME_ERR_CODE"})
 				},
 			},
 		},

--- a/examples/starwars/schema.go
+++ b/examples/starwars/schema.go
@@ -155,8 +155,8 @@ func init() {
 			&gql.Field{
 				Name: "id",
 				Type: gql.NewNonNull(gql.String),
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
-					if human, ok := parent.(StarWarsChar); ok {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
+					if human, ok := ctx.Parent().(StarWarsChar); ok {
 						return human.ID, nil
 					}
 					return nil, nil
@@ -165,8 +165,8 @@ func init() {
 			&gql.Field{
 				Name: "name",
 				Type: gql.String,
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
-					if human, ok := parent.(StarWarsChar); ok {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
+					if human, ok := ctx.Parent().(StarWarsChar); ok {
 						return human.Name, nil
 					}
 					return nil, nil
@@ -175,8 +175,8 @@ func init() {
 			&gql.Field{
 				Name: "friends",
 				Type: gql.NewList(characterInterface),
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
-					if human, ok := parent.(StarWarsChar); ok {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
+					if human, ok := ctx.Parent().(StarWarsChar); ok {
 						return human.Friends, nil
 					}
 					return nil, nil
@@ -185,8 +185,8 @@ func init() {
 			&gql.Field{
 				Name: "appearsIn",
 				Type: gql.NewList(episodeEnum),
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
-					if human, ok := parent.(StarWarsChar); ok {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
+					if human, ok := ctx.Parent().(StarWarsChar); ok {
 						return human.AppearsIn, nil
 					}
 					return nil, nil
@@ -195,8 +195,8 @@ func init() {
 			&gql.Field{
 				Name: "homePlanet",
 				Type: gql.String,
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
-					if human, ok := parent.(StarWarsChar); ok {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
+					if human, ok := ctx.Parent().(StarWarsChar); ok {
 						return human.HomePlanet, nil
 					}
 					return nil, nil
@@ -211,8 +211,8 @@ func init() {
 			&gql.Field{
 				Name: "id",
 				Type: gql.NewNonNull(gql.String),
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
-					if droid, ok := parent.(StarWarsChar); ok {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
+					if droid, ok := ctx.Parent().(StarWarsChar); ok {
 						return droid.ID, nil
 					}
 					return nil, nil
@@ -221,8 +221,8 @@ func init() {
 			&gql.Field{
 				Name: "name",
 				Type: gql.NewNonNull(gql.String),
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
-					if droid, ok := parent.(StarWarsChar); ok {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
+					if droid, ok := ctx.Parent().(StarWarsChar); ok {
 						return droid.Name, nil
 					}
 					return nil, nil
@@ -231,8 +231,8 @@ func init() {
 			&gql.Field{
 				Name: "friends",
 				Type: gql.NewNonNull(gql.String),
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
-					if droid, ok := parent.(StarWarsChar); ok {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
+					if droid, ok := ctx.Parent().(StarWarsChar); ok {
 						friends := []map[string]interface{}{}
 						for _, friend := range droid.Friends {
 							friends = append(friends, map[string]interface{}{
@@ -248,8 +248,8 @@ func init() {
 			&gql.Field{
 				Name: "appearsIn",
 				Type: gql.NewList(episodeEnum),
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
-					if droid, ok := parent.(StarWarsChar); ok {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
+					if droid, ok := ctx.Parent().(StarWarsChar); ok {
 						return droid.AppearsIn, nil
 					}
 					return nil, nil
@@ -258,8 +258,8 @@ func init() {
 			&gql.Field{
 				Name: "primaryFunction",
 				Type: gql.NewNonNull(gql.String),
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
-					if droid, ok := parent.(StarWarsChar); ok {
+				Resolver: func(ctx gql.Context) (interface{}, error) {
+					if droid, ok := ctx.Parent().(StarWarsChar); ok {
 						return droid.PrimaryFunction, nil
 					}
 					return nil, nil
@@ -280,8 +280,8 @@ func init() {
 						Type: episodeEnum,
 					},
 				},
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
-					return GetHero(args["episode"]), nil
+				Resolver: func(ctx gql.Context) (interface{}, error) {
+					return GetHero(ctx.Args()["episode"]), nil
 				},
 			},
 			&gql.Field{
@@ -293,8 +293,8 @@ func init() {
 						Type: gql.NewNonNull(gql.String),
 					},
 				},
-				Resolver: func(ctx context.Context, parent interface{}, args map[string]interface{}) (interface{}, error) {
-					id, err := strconv.Atoi(args["id"].(string))
+				Resolver: func(ctx gql.Context) (interface{}, error) {
+					id, err := strconv.Atoi(ctx.Args()["id"].(string))
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/gql/context.go
+++ b/pkg/gql/context.go
@@ -6,13 +6,6 @@ import (
 	"time"
 )
 
-type gqlContext interface {
-	context.Context
-	Get(key string) interface{}
-	Set(key string, v interface{})
-	Delete(key string)
-}
-
 const (
 	keyOperationName string = "gql_operation_name"
 	keyRawVariables  string = "gql_raw_variables"
@@ -47,15 +40,15 @@ func (c *eCtx) Deadline() (time.Time, bool) {
 }
 
 func (c *eCtx) Value(key interface{}) interface{} {
-	return c.Value(key)
+	return c.ctx.Value(key)
 }
 
 func (c *eCtx) Done() <-chan struct{} {
-	return c.Done()
+	return c.ctx.Done()
 }
 
 func (c *eCtx) Err() error {
-	return c.Err()
+	return c.ctx.Err()
 }
 
 func (c *eCtx) Get(key string) interface{} {
@@ -80,3 +73,36 @@ func (c *eCtx) Delete(key string) {
 }
 
 var _ context.Context = (*eCtx)(nil)
+
+type Context interface {
+	context.Context
+	Path() []interface{}
+	// 	Fields() []string
+	Args() map[string]interface{}
+	Parent() interface{}
+}
+
+type resolveContext struct {
+	context.Context
+	eCtx   *eCtx
+	path   []interface{}
+	fields []string
+	args   map[string]interface{}
+	parent interface{}
+}
+
+func (r *resolveContext) Path() []interface{} {
+	return r.path
+}
+
+func (r *resolveContext) Fields() []string {
+	return r.fields
+}
+
+func (r *resolveContext) Args() map[string]interface{} {
+	return r.args
+}
+
+func (r *resolveContext) Parent() interface{} {
+	return r.parent
+}

--- a/pkg/gql/context.go
+++ b/pkg/gql/context.go
@@ -75,7 +75,7 @@ func (c *eCtx) Delete(key string) {
 var _ context.Context = (*eCtx)(nil)
 
 type Context interface {
-	context.Context
+	Context() context.Context
 	Path() []interface{}
 	// 	Fields() []string
 	Args() map[string]interface{}
@@ -83,12 +83,16 @@ type Context interface {
 }
 
 type resolveContext struct {
-	context.Context
+	ctx    context.Context
 	eCtx   *eCtx
 	path   []interface{}
 	fields []string
 	args   map[string]interface{}
 	parent interface{}
+}
+
+func (r *resolveContext) Context() context.Context {
+	return r.ctx
 }
 
 func (r *resolveContext) Path() []interface{} {

--- a/pkg/gql/errors.go
+++ b/pkg/gql/errors.go
@@ -1,9 +1,5 @@
 package gql
 
-import (
-	"context"
-)
-
 type Errors []*Error
 
 type Error struct {
@@ -22,14 +18,32 @@ type ErrorLocation struct {
 	Column int `json:"column"`
 }
 
-func NewError(ctx context.Context, msg string, extensions map[string]interface{}) *Error {
-	return &Error{
-		Message:    msg,
-		Extensions: extensions,
+func NewError(msg string, extensions map[string]interface{}) CustomError {
+	return &cErr{
+		msg:  msg,
+		exts: extensions,
 	}
 }
 
+type cErr struct {
+	msg  string
+	exts map[string]interface{}
+}
+
+func (c *cErr) Error() string {
+	return c.msg
+}
+
+func (c *cErr) GetMessage() string {
+	return c.msg
+}
+
+func (c *cErr) GetExtensions() map[string]interface{} {
+	return c.exts
+}
+
 type CustomError interface {
+	error
 	GetMessage() string
 	GetExtensions() map[string]interface{}
 }

--- a/pkg/gql/execution.go
+++ b/pkg/gql/execution.go
@@ -504,12 +504,12 @@ func resolveMetaFields(ctx *eCtx, fs []*ast.Field, t Type, res map[string]interf
 func resolveFieldValue(ctx *eCtx, path []interface{}, fast *ast.Field, ot *Object, ov interface{}, fn string, args map[string]interface{}) interface{} {
 	f := getFieldOfFields(fn, ot.GetFields())
 	rCtx := &resolveContext{
-		Context: ctx.ctx,
-		eCtx:    ctx,
-		args:    args,
-		parent:  ov,
-		path:    path,
-		fields:  []string{},
+		ctx:    ctx.ctx, // this is the original context
+		eCtx:   ctx,     // execution context
+		args:   args,
+		parent: ov, // parent's value
+		path:   path,
+		fields: []string{}, // currently it's not implemented
 	}
 
 	v, err := f.Resolve(rCtx)
@@ -539,9 +539,6 @@ func resolveFieldValue(ctx *eCtx, path []interface{}, fast *ast.Field, ot *Objec
 			})
 		}
 		v = nil
-	}
-	if f.GetType().GetKind() == NonNullKind && v == nil {
-		// TODO: raise field error
 	}
 	return v
 }

--- a/pkg/gql/execution.go
+++ b/pkg/gql/execution.go
@@ -503,7 +503,16 @@ func resolveMetaFields(ctx *eCtx, fs []*ast.Field, t Type, res map[string]interf
 
 func resolveFieldValue(ctx *eCtx, path []interface{}, fast *ast.Field, ot *Object, ov interface{}, fn string, args map[string]interface{}) interface{} {
 	f := getFieldOfFields(fn, ot.GetFields())
-	v, err := f.Resolve(ctx, ov, args)
+	rCtx := &resolveContext{
+		Context: ctx.ctx,
+		eCtx:    ctx,
+		args:    args,
+		parent:  ov,
+		path:    path,
+		fields:  []string{},
+	}
+
+	v, err := f.Resolve(rCtx)
 	if err != nil {
 		if e, ok := err.(CustomError); ok {
 			ctx.res.addErr(&Error{

--- a/pkg/gql/execution.go
+++ b/pkg/gql/execution.go
@@ -37,7 +37,7 @@ func Execute(ctx context.Context, s *Schema, p ExecuteParams) *Result {
 	if err != nil {
 		return &Result{
 			ctx:    ctx,
-			Errors: Errors{NewError(ctx, err.Error(), nil)},
+			Errors: Errors{&Error{err.Error(), nil, nil, nil}},
 		}
 	}
 	types, directives := getTypes(s)
@@ -170,7 +170,7 @@ func resolveOperation(ctx *eCtx) *Result {
 	}
 	return &Result{
 		ctx:    ctx,
-		Errors: Errors{NewError(ctx, "invalid operation", nil)},
+		Errors: Errors{&Error{"invalid operation", nil, nil, nil}},
 	}
 }
 

--- a/pkg/gql/validation.go
+++ b/pkg/gql/validation.go
@@ -14,14 +14,14 @@ func validate(ctx *eCtx) {
 	for _, o := range ctx.Get(keyQuery).(*ast.Document).Operations {
 		// 5.2.1 - Named Operation Definitions
 		if _, ok := ops[o.Name]; ok && o.Name != "" {
-			ctx.res.addErr(NewError(ctx, fmt.Sprintf(ErrValidateOperationName, o.Name), nil))
+			ctx.res.addErr(&Error{fmt.Sprintf(ErrValidateOperationName, o.Name), nil, nil, nil})
 		} else {
 			ops[o.Name] = true
 		}
 
 		// 5.2.2 - Anonymous Operation Definitions
 		if o.Name == "" && len(ctx.Get(keyQuery).(*ast.Document).Operations) > 1 {
-			ctx.res.addErr(NewError(ctx, fmt.Sprintf(ErrAnonymousOperationDefinitions), nil))
+			ctx.res.addErr(&Error{fmt.Sprintf(ErrAnonymousOperationDefinitions), nil, nil, nil})
 		}
 
 		// TODO: 5.2.3 - Subscription Operation Definitions
@@ -53,7 +53,7 @@ func validateMetaField(ctx *eCtx, f *ast.Field, t Type) {
 		}
 	default:
 		{
-			ctx.res.addErr(NewError(ctx, fmt.Sprintf(ErrFieldDoesNotExist, f.Name, t.GetName()), nil))
+			ctx.res.addErr(&Error{fmt.Sprintf(ErrFieldDoesNotExist, f.Name, t.GetName()), nil, nil, nil})
 		}
 	}
 }
@@ -67,7 +67,7 @@ func fieldsInSetCanMerge(ctx *eCtx, set []ast.Selection, t Type) {
 			for i := 1; i < len(fields); i++ {
 				if !sameResponseShape(ctx, fields[0], fields[i], t) {
 					// TODO: raise error for selection set can not be merged
-					ctx.res.addErr(NewError(ctx, fmt.Sprintf(ErrResponseShapeMismatch, "response shape is not the same"), nil))
+					ctx.res.addErr(&Error{fmt.Sprintf(fmt.Sprintf(ErrResponseShapeMismatch, "response shape is not the same")), nil, nil, nil})
 				}
 				// var ta, tb = getFieldOfFields(fields[0].Name, fs).GetType(), getFieldOfFields(fields[i].Name, fs).GetType()
 				var pa, pb Type
@@ -89,11 +89,11 @@ func fieldsInSetCanMerge(ctx *eCtx, set []ast.Selection, t Type) {
 				if reflect.DeepEqual(pa, pb) || (pa.GetKind() != ObjectKind || pb.GetKind() != ObjectKind) {
 					if fields[0].Name != fields[i].Name {
 						// TODO: raise error that selection set can not be merged
-						ctx.res.addErr(NewError(ctx, fmt.Sprintf(ErrResponseShapeMismatch, "field names are not equal"), nil))
+						ctx.res.addErr(&Error{fmt.Sprintf(fmt.Sprintf(ErrResponseShapeMismatch, "field names are not equal")), nil, nil, nil})
 					}
 					if !reflect.DeepEqual(fields[0].Arguments, fields[1].Arguments) {
 						// TODO: raise error that selection set can not be merged (due to arguments don't match)
-						ctx.res.addErr(NewError(ctx, fmt.Sprintf(ErrResponseShapeMismatch, "arguments don't match"), nil))
+						ctx.res.addErr(&Error{fmt.Sprintf(fmt.Sprintf(ErrResponseShapeMismatch, "arguments don't match")), nil, nil, nil})
 					}
 					mergedSet := append(fields[0].SelectionSet, fields[1].SelectionSet...)
 					fieldsInSetCanMerge(ctx, mergedSet, getFieldOfFields(fields[0].Name, pa.(hasFields).GetFields()).GetType())
@@ -190,11 +190,11 @@ func validateSelectionSet(ctx *eCtx, set []ast.Selection, t Type) {
 								if len(f.SelectionSet) > 0 {
 									validateSelectionSet(ctx, f.SelectionSet, selType)
 								} else {
-									ctx.res.addErr(NewError(ctx, fmt.Sprintf(ErrLeafFieldSelectionsSelectionMissing, selType.GetName()), nil))
+									ctx.res.addErr(&Error{fmt.Sprintf(fmt.Sprintf(ErrLeafFieldSelectionsSelectionMissing, selType.GetName())), nil, nil, nil})
 								}
 							} else if selType.GetKind() == ScalarKind || selType.GetKind() == EnumKind {
 								if len(f.SelectionSet) != 0 {
-									ctx.res.addErr(NewError(ctx, fmt.Sprintf(ErrLeafFieldSelectionsSelectionNotAllowed, selType.GetName()), nil))
+									ctx.res.addErr(&Error{fmt.Sprintf(fmt.Sprintf(ErrLeafFieldSelectionsSelectionNotAllowed, selType.GetName())), nil, nil, nil})
 								}
 							}
 
@@ -205,7 +205,7 @@ func validateSelectionSet(ctx *eCtx, set []ast.Selection, t Type) {
 					// 5.3.1 - Field Selections on Objects, Interfaces, and Unions Types
 					// if field does NOT exist on type
 					if !ok {
-						ctx.res.addErr(NewError(ctx, fmt.Sprintf(ErrFieldDoesNotExist, f.Name, t.GetName()), nil))
+						ctx.res.addErr(&Error{fmt.Sprintf(fmt.Sprintf(ErrFieldDoesNotExist, f.Name, t.GetName())), nil, nil, nil})
 					}
 				} else if i, ok := t.(*Interface); ok {
 					ok = false
@@ -220,11 +220,11 @@ func validateSelectionSet(ctx *eCtx, set []ast.Selection, t Type) {
 								if len(f.SelectionSet) > 0 {
 									validateSelectionSet(ctx, f.SelectionSet, selType)
 								} else {
-									ctx.res.addErr(NewError(ctx, fmt.Sprintf(ErrLeafFieldSelectionsSelectionMissing, selType.GetName()), nil))
+									ctx.res.addErr(&Error{fmt.Sprintf(fmt.Sprintf(ErrLeafFieldSelectionsSelectionMissing, selType.GetName())), nil, nil, nil})
 								}
 							} else if selType.GetKind() == ScalarKind || selType.GetKind() == EnumKind {
 								if len(f.SelectionSet) != 0 {
-									ctx.res.addErr(NewError(ctx, fmt.Sprintf(ErrLeafFieldSelectionsSelectionNotAllowed, selType.GetName()), nil))
+									ctx.res.addErr(&Error{fmt.Sprintf(fmt.Sprintf(ErrLeafFieldSelectionsSelectionNotAllowed, selType.GetName())), nil, nil, nil})
 								}
 							}
 
@@ -235,7 +235,7 @@ func validateSelectionSet(ctx *eCtx, set []ast.Selection, t Type) {
 					// 5.3.1 - Field Selections on Objects, Interfaces, and Unions Types
 					// if field does NOT exist on type
 					if !ok {
-						ctx.res.addErr(NewError(ctx, fmt.Sprintf(ErrFieldDoesNotExist, f.Name, t.GetName()), nil))
+						ctx.res.addErr(&Error{fmt.Sprintf(fmt.Sprintf(ErrFieldDoesNotExist, f.Name, t.GetName())), nil, nil, nil})
 					}
 				} else if _, ok := t.(*Union); ok {
 					// TODO: add error, that field selection on Union type does not supported (only fragments)


### PR DESCRIPTION
- changed the field resolvers to `func(gql.Context) (interface{}, error)`
- changed `gql.NewError` to `gql.NewError(msg string, extensions map[string]interface{}) gql.CustomError`
